### PR TITLE
Allow the SwSh Egg Operation "Keep" table to expand

### DIFF
--- a/remotecontrollerwindow.ui
+++ b/remotecontrollerwindow.ui
@@ -5139,6 +5139,9 @@ Enter Trade Partner Name:</string>
                         <property name="orientation">
                          <enum>Qt::Vertical</enum>
                         </property>
+                        <property name="sizeType">
+                         <enum>QSizePolicy::Preferred</enum>
+                        </property>
                         <property name="sizeHint" stdset="0">
                          <size>
                           <width>20</width>

--- a/remotecontrollerwindow.ui
+++ b/remotecontrollerwindow.ui
@@ -18,7 +18,7 @@
   </property>
   <property name="maximumSize">
    <size>
-    <width>1407</width>
+    <width>16777215</width>
     <height>16777215</height>
    </size>
   </property>

--- a/remotecontrollerwindow.ui
+++ b/remotecontrollerwindow.ui
@@ -18,7 +18,7 @@
   </property>
   <property name="maximumSize">
    <size>
-    <width>16777215</width>
+    <width>1407</width>
     <height>16777215</height>
    </size>
   </property>


### PR DESCRIPTION
The "Keep" egg table currently cannot be resized in either direction because:

- The containing window cannot be resized horizontally
- The spacer below the table takes "expansion priority", so the table cannot expand vertically

This PR removes the horizontal cap on the window and sets the spacer to stop expanding when it hits its preferred size.