### PR TITLE
Adjust Discord notifications

### DIFF
--- a/SmartPrograms/PokemonSwSh/smarteggoperation.cpp
+++ b/SmartPrograms/PokemonSwSh/smarteggoperation.cpp
@@ -1321,6 +1321,14 @@ void SmartEggOperation::runNextState()
             }
             else if (isShiny)
             {
+                // send discord message
+                if (m_programSettings.m_shinyDetection == ShinyDetectionType::SDT_Disable)
+                {
+                    QImage frame;
+                    m_videoManager->getFrame(frame);
+                    sendDiscordMessage("Unmatched Shiny Found!", false, QColor(255,255,0), &frame);
+                }
+
                 emit printLog(log + " is SHINY!!! Moving it to Keep Box!", LOG_SUCCESS);
                 runKeepPokemonCommand();
                 break;

--- a/SmartPrograms/smartprogrambase.cpp
+++ b/SmartPrograms/smartprogrambase.cpp
@@ -994,7 +994,7 @@ void SmartProgramBase::runNextState()
             Discord::EmbedField embedField("Error Message", m_errorMsg, false);
             QImage frame;
             m_videoManager->getFrame(frame);
-            sendDiscordMessage("Error Occured", false, LOG_ERROR, &frame, {embedField});
+            sendDiscordError("Error Occured", LOG_ERROR, &frame, {embedField});
         }
 
         stop();
@@ -1164,6 +1164,16 @@ void SmartProgramBase::updateStats()
 
 void SmartProgramBase::sendDiscordMessage(const QString &title, bool isMention, QColor color, const QImage *img, const QList<Discord::EmbedField> &fields)
 {
+    sendDiscordMessage(title, isMention, false, color, img, fields);
+}
+
+void SmartProgramBase::sendDiscordError(const QString &title, QColor color, const QImage *img, const QList<Discord::EmbedField> &fields)
+{
+    sendDiscordMessage(title, false, true, color, img, fields);
+}
+
+void SmartProgramBase::sendDiscordMessage(const QString &title, bool isMention, bool isError, QColor color, const QImage *img, const QList<Discord::EmbedField> &fields)
+{
     if (!m_discordSettings->canSendMessage()) return;
 
     Discord::Embed embed = m_discordSettings->getEmbedTemplate(title);
@@ -1191,6 +1201,13 @@ void SmartProgramBase::sendDiscordMessage(const QString &title, bool isMention, 
     embed.addField(Discord::EmbedField("Smart Program Stats", fieldMsg, false));
 
     // send message
-    m_discordSettings->sendMessage(embed, isMention, img);
+    if (isError)
+    {
+        m_discordSettings->sendError(embed, img);
+    }
+    else
+    {
+        m_discordSettings->sendMessage(embed, isMention, img);
+    }
     m_hadDiscordMessage = true;
 }

--- a/SmartPrograms/smartprogrambase.h
+++ b/SmartPrograms/smartprogrambase.h
@@ -551,6 +551,9 @@ public:
     void sendDiscordError(QString const& title, QColor color = QColor(0,0,0), QImage const* img = nullptr, QList<Discord::EmbedField> const& fields = {});
 
 protected:
+    void sendDiscordMessage(QString const& title, bool isMention, bool isError, QColor color = QColor(0,0,0), QImage const* img = nullptr, QList<Discord::EmbedField> const& fields = {});
+
+protected:
     AudioManager*           m_audioManager;
     VideoManager*           m_videoManager;
     DiscordSettings*        m_discordSettings;

--- a/SmartPrograms/smartprogrambase.h
+++ b/SmartPrograms/smartprogrambase.h
@@ -548,6 +548,7 @@ protected:
 public:
     // Discord messages
     void sendDiscordMessage(QString const& title, bool isMention, QColor color = QColor(0,0,0), QImage const* img = nullptr, QList<Discord::EmbedField> const& fields = {});
+    void sendDiscordError(QString const& title, QColor color = QColor(0,0,0), QImage const* img = nullptr, QList<Discord::EmbedField> const& fields = {});
 
 protected:
     AudioManager*           m_audioManager;

--- a/discordsettings.cpp
+++ b/discordsettings.cpp
@@ -21,6 +21,7 @@ DiscordSettings::DiscordSettings(QWidget *parent) :
     ui->LE_Owner->setText(m_settings->value("DiscordOwner", "").toString());
     ui->CB_Launch->setChecked(m_settings->value("DiscordStart", false).toBool());
     ui->CB_StatusDM->setChecked(m_settings->value("DiscordStatusDM", true).toBool());
+    ui->CB_MentionError->setChecked(m_settings->value("DiscordMentionError", true).toBool());
     if (ui->CB_Launch->isChecked())
     {
         on_PB_Connect_clicked();
@@ -41,6 +42,7 @@ void DiscordSettings::closeEvent(QCloseEvent *event)
     m_settings->setValue("DiscordOwner", ui->LE_Owner->text());
     m_settings->setValue("DiscordStart", ui->CB_Launch->isChecked());
     m_settings->setValue("DiscordStatusDM", ui->CB_StatusDM->isChecked());
+    m_settings->setValue("DiscordMentionError", ui->CB_MentionError->isChecked());
 }
 
 void DiscordSettings::on_LE_Token_textChanged(const QString &arg1)
@@ -181,6 +183,12 @@ void DiscordSettings::sendMessage(const Discord::Embed &embed, bool isMention, c
             }
         );
     }
+}
+
+void DiscordSettings::sendError(const Discord::Embed &embed, const QImage *img)
+{
+    isMention = ui->CB_MentionError->isChecked();
+    sendMessage(embed, isMention, img);
 }
 
 void DiscordSettings::sendMessage(snowflake_t channelId, const QString &content)

--- a/discordsettings.cpp
+++ b/discordsettings.cpp
@@ -187,7 +187,7 @@ void DiscordSettings::sendMessage(const Discord::Embed &embed, bool isMention, c
 
 void DiscordSettings::sendError(const Discord::Embed &embed, const QImage *img)
 {
-    isMention = ui->CB_MentionError->isChecked();
+    bool isMention = ui->CB_MentionError->isChecked();
     sendMessage(embed, isMention, img);
 }
 

--- a/discordsettings.h
+++ b/discordsettings.h
@@ -50,6 +50,7 @@ public:
     // senders
     bool canSendMessage();
     void sendMessage(Discord::Embed const& embed, bool isMention, QImage const* img = nullptr);
+    void sendError(const Discord::Embed &embed, const QImage *img = nullptr);
 
     void sendMessage(snowflake_t channelId, QString const& content);
     void sendImageMessage(snowflake_t channelId, QImage const& img);

--- a/discordsettings.ui
+++ b/discordsettings.ui
@@ -166,6 +166,16 @@
     </widget>
    </item>
    <item>
+    <widget class="QCheckBox" name="CB_MentionError">
+     <property name="text">
+      <string>Mention Owner on Error</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
     <layout class="QHBoxLayout" name="horizontalLayout_4">
      <item>
       <widget class="QPushButton" name="PB_Channel">


### PR DESCRIPTION
This makes two adjustments to Discord notifications:

1. General
   - Add an option to mention the bot owner if an error occurs
2. SwSh Egg Operation
   - If a shiny is found which doesn't match the Keep list and shiny detection is off, send a Discord message
(I think this is already the case for BDSP)